### PR TITLE
Graphene (Coreference-Resolution) Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,23 @@ _Docker Compose_ will assemble all software components and ease the setup of thi
 version: '2'
 
 services:
- 
+
+  coreference:
+    depends_on:
+      - corenlp
+    image: "lambdacube/pycobalt:v1.1.1"
+    environment:
+      - PYCOBALT_CORENLP=http://corenlp:9000
+    expose:
+      - "5128"
+    ports:
+      - "5128:5128"
+
+  corenlp:
+    image: "lambdacube/corenlp:3.7.0"
+    expose:
+      - "9000"
+
   elastic:
     image: elasticsearch:5.1.1
     container_name: elastic
@@ -187,4 +203,5 @@ And the output is a JSON response.
 - Andre Freitas
 - Bernhard Bermeitinger
 - Leonardo Souza
+- Matthias Cetto
 - Siegfried Handschuh

--- a/stargraph-core/pom.xml
+++ b/stargraph-core/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <es.version>5.1.1</es.version>
         <corenlp.version>3.7.0</corenlp.version>
+        <graphene.version>2.0.0-SNAPSHOT</graphene.version>
     </properties>
 
     <build>
@@ -56,6 +57,13 @@
             <groupId>net.stargraph</groupId>
             <artifactId>stargraph-model</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <!-- Graphene-Core -->
+        <dependency>
+            <groupId>org.lambda3.graphene</groupId>
+            <artifactId>graphene-core</artifactId>
+            <version>${graphene.version}</version>
         </dependency>
 
         <dependency>

--- a/stargraph-core/src/main/java/net/stargraph/core/processors/CoreferenceResolutionProcessor.java
+++ b/stargraph-core/src/main/java/net/stargraph/core/processors/CoreferenceResolutionProcessor.java
@@ -1,0 +1,69 @@
+package net.stargraph.core.processors;
+
+/*-
+ * ==========================License-Start=============================
+ * stargraph-core
+ * --------------------------------------------------------------------
+ * Copyright (C) 2017 Lambda^3
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * ==========================License-End===============================
+ */
+
+import com.typesafe.config.Config;
+import net.stargraph.data.processor.BaseProcessor;
+import net.stargraph.data.processor.Holder;
+import net.stargraph.data.processor.ProcessorException;
+import net.stargraph.model.*;
+import org.lambda3.graphene.core.Graphene;
+import org.lambda3.graphene.core.coreference.model.CoreferenceContent;
+
+import java.io.Serializable;
+
+/**
+ * Can be placed in the workflow to resolve coreferences.
+ */
+public final class CoreferenceResolutionProcessor extends BaseProcessor {
+    public static String name = "coref-processor";
+
+    private static final Graphene GRAPHENE = new Graphene();
+
+    public CoreferenceResolutionProcessor(Config config) {
+        super(config);
+    }
+
+    @Override
+    public void doRun(Holder<Serializable> holder) throws ProcessorException {
+        Serializable entry = holder.get();
+
+        if (entry instanceof Document) {
+            Document document = (Document)entry;
+
+            CoreferenceContent cc = GRAPHENE.doCoreference(document.getText());
+            String resolved = cc.getSubstitutedText();
+
+            holder.set(new Document(document.getTitle(), resolved));
+        }
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/stargraph-core/src/main/java/net/stargraph/core/processors/Processors.java
+++ b/stargraph-core/src/main/java/net/stargraph/core/processors/Processors.java
@@ -49,6 +49,7 @@ public final class Processors {
             put(RegExFilterProcessor.name, RegExFilterProcessor.class);
             put(StopPropertyFilterProcessor.name, StopPropertyFilterProcessor.class);
             put(LengthFilterProcessor.name, LengthFilterProcessor.class);
+            put(CoreferenceResolutionProcessor.name, CoreferenceResolutionProcessor.class);
             put(PassageProcessor.name, PassageProcessor.class);
         }};
     }

--- a/stargraph-core/src/main/resources/reference.conf
+++ b/stargraph-core/src/main/resources/reference.conf
@@ -84,6 +84,8 @@ processor = {
     wordnet-dir = /usr/share/wordnet
   }
 
+  coref-processor = {}
+
   passage-processor = {}
 }
 
@@ -1713,6 +1715,9 @@ stargraph = {
       provider.class = net.stargraph.core.DocumentProviderFactory
 
       processors = [
+        {
+          coref-processor: ${processor.coref-processor}
+        },
         {
           passage-processor: {
             language = ${stargraph.kb.obama.language}

--- a/stargraph-core/src/main/resources/reference.conf
+++ b/stargraph-core/src/main/resources/reference.conf
@@ -1,3 +1,12 @@
+graphene {
+  coreference {
+    url = "http://coreference:5128/resolve"
+    text-path = "text"
+    wiki-path = "wiki"
+    wiki-link-path = "link"
+  }
+}
+
 excluded-properties = [
   "^rdfs:seeAlso$",
   "^dbp:imdb$",

--- a/stargraph-server/src/main/config/logback.xml
+++ b/stargraph-server/src/main/config/logback.xml
@@ -32,6 +32,7 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
+    <logger name="org.lambda3.graphene" level="INFO" additivity="true"/>
     <logger name="org.elasticsearch" level="INFO" additivity="true"/>
     <logger name="org.apache" level="WARN" additivity="true"/>
     <logger name="org.glassfish" level="WARN" additivity="true"/>


### PR DESCRIPTION
Integrated graphene-core as a maven dependency (for using Coreference-Resolution).
Also updated the docker-compose deployment description in the README.
Implemented a new Coreference-Resolution processor for the `documents` type.